### PR TITLE
fix: 3box/v03id derivation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/identity-wallet
     docker:
-      - image: cimg/node:12.18
+      - image: cimg/node:14.15
     steps:
       - checkout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/store": "^2.0.2",
         "babel-core": "7.0.0-bridge.0",
         "babel-loader": "^8.2.2",
+        "dag-jose": "^0.3.0",
         "eslint": "^7.15.0",
         "eslint-config-3box": "^0.2.0",
         "ipfs": "^0.52.3",
@@ -7510,6 +7511,17 @@
       "dependencies": {
         "cids": "^1.0.0",
         "ipld-dag-cbor": "^0.17.0"
+      }
+    },
+    "node_modules/dag-jose": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-0.3.0.tgz",
+      "integrity": "sha512-2utzhBhsrMf7nnpqnT2MVm/2aLhwGSbbSpIDvHN6czvTk1mqrxg6L/VR7QdF2qLOeW90A5ZQ4OpN672TZ6LM5Q==",
+      "dev": true,
+      "dependencies": {
+        "borc": "^2.1.2",
+        "cids": "^1.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "node_modules/dag-jose-utils": {
@@ -31385,6 +31397,17 @@
       "requires": {
         "cids": "^1.0.0",
         "ipld-dag-cbor": "^0.17.0"
+      }
+    },
+    "dag-jose": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-0.3.0.tgz",
+      "integrity": "sha512-2utzhBhsrMf7nnpqnT2MVm/2aLhwGSbbSpIDvHN6czvTk1mqrxg6L/VR7QdF2qLOeW90A5ZQ4OpN672TZ6LM5Q==",
+      "dev": true,
+      "requires": {
+        "borc": "^2.1.2",
+        "cids": "^1.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "dag-jose-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "3id-did-provider",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "3id-did-provider",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
-        "@ceramicnetwork/doctype-tile": "^0.13.0",
-        "@ceramicnetwork/http-client": "^0.9.3",
+        "@ceramicnetwork/doctype-tile": "^0.13.3",
+        "@ceramicnetwork/http-client": "^0.9.6",
         "@ceramicstudio/idx-constants": "^0.6.0",
         "@ethersproject/hdnode": "^5.0.8",
         "@stablelib/random": "^1.0.0",
@@ -1220,15 +1220,25 @@
       "dev": true
     },
     "node_modules/@ceramicnetwork/3id-did-resolver": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.6.7.tgz",
-      "integrity": "sha512-AQodHN5OK5UbKKi2pMsgwEK5/N4sG+ayin3BDSNVTpP5OJEllj7inNlKuH7LfCUMphwJTX6SULIaZtHex9j+sg==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.6.10.tgz",
+      "integrity": "sha512-v+tCi2r3x+/B7fquFNUeJk9MYkK23C5/unylAl6MTik4TP1Je8WtFsvlYMd6jNBcg7Kun5tjdoFs+IT6o5w5kA==",
       "dependencies": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ceramicnetwork/docid": "^0.4.5",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@ceramicnetwork/docid": "^0.4.6",
         "cids": "1.0.2",
         "cross-fetch": "^3.0.6",
-        "uint8arrays": "^1.1.0"
+        "lru_map": "^0.4.1",
+        "uint8arrays": "^2.0.5"
+      }
+    },
+    "node_modules/@ceramicnetwork/3id-did-resolver/node_modules/uint8arrays": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+      "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.5"
       }
     },
     "node_modules/@ceramicnetwork/blockchain-utils-linking": {
@@ -1280,19 +1290,28 @@
       }
     },
     "node_modules/@ceramicnetwork/common": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-0.15.7.tgz",
-      "integrity": "sha512-7TSOFiTvvM/eFeT671og6ihbiYzlUPIA6DCzAuQHjN2Nme+o5+oiLZaFqwYvpytz0ISs/1jXSUsFfkQEkilphw==",
+      "version": "0.15.9",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-0.15.9.tgz",
+      "integrity": "sha512-ubUgDToLpsd6QELZi9RsMUsr1H4mNtjPwaGRJwT4rMt9lJalHtaw+KoOJLcSeEED6CzQEZUsBxlI9Dr33W4Bew==",
       "dependencies": {
-        "@ceramicnetwork/docid": "^0.4.5",
+        "@ceramicnetwork/docid": "^0.4.6",
         "cids": "1.0.2",
-        "dag-jose": "^0.3.0",
         "did-resolver": "^2.1.1",
+        "events": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
         "loglevel": "^1.7.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "lru_map": "^0.4.1",
-        "uint8arrays": "^1.1.0"
+        "uint8arrays": "^2.0.5"
+      }
+    },
+    "node_modules/@ceramicnetwork/common/node_modules/uint8arrays": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+      "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.5"
       }
     },
     "node_modules/@ceramicnetwork/core": {
@@ -1335,24 +1354,55 @@
       }
     },
     "node_modules/@ceramicnetwork/docid": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.4.5.tgz",
-      "integrity": "sha512-mrWqkM1hLSjNBIsca7Kex0TfSVxfi/r9X0113H/T3FxSQHwtFteOQLNwMjGpV5RnKcdjwUQgml1cQUnJIRmmDQ==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.4.6.tgz",
+      "integrity": "sha512-fZbmtOkgK8D6eKACRUAT3m6jvNyhAi2Q9pivugld9pc5CzmGYEtDAwtTdNr1eugMVAxxN04UhOENBr0lW9RFKA==",
       "dependencies": {
         "cids": "1.0.2",
         "multibase": "3.0.1",
-        "multicodec": "2.0.4",
-        "uint8arrays": "^1.1.0",
+        "multicodec": "2.0.0",
+        "uint8arrays": "^2.0.5",
         "varint": "^6.0.0"
       }
     },
-    "node_modules/@ceramicnetwork/doctype-caip10-link": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-caip10-link/-/doctype-caip10-link-0.13.0.tgz",
-      "integrity": "sha512-/FzokYBeduVFIuqVGWvfa+ToNGzXn2crTmvxj61oWDI08NHTqHni3ewD91q0qeZv8F3nj4dzff1NujMs5u/glQ==",
+    "node_modules/@ceramicnetwork/docid/node_modules/multicodec": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+      "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
       "dependencies": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@types/lodash.clonedeep": "^4.5.6",
+        "uint8arrays": "1.0.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/@ceramicnetwork/docid/node_modules/multicodec/node_modules/uint8arrays": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+      "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
+      }
+    },
+    "node_modules/@ceramicnetwork/docid/node_modules/multicodec/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
+    "node_modules/@ceramicnetwork/docid/node_modules/uint8arrays": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+      "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.5"
+      }
+    },
+    "node_modules/@ceramicnetwork/doctype-caip10-link": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-caip10-link/-/doctype-caip10-link-0.13.2.tgz",
+      "integrity": "sha512-sHOB8Uh/4ivvMhfkk3QobAJytce1vzgSamXKjjcjaeAoviqOG5d4XgJ07uoeQVANpmBN4yzRlnxuMtX1b9UALw==",
+      "dependencies": {
+        "@ceramicnetwork/common": "^0.15.9",
         "cids": "1.0.2"
       }
     },
@@ -1368,22 +1418,14 @@
       }
     },
     "node_modules/@ceramicnetwork/doctype-tile": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-tile/-/doctype-tile-0.13.0.tgz",
-      "integrity": "sha512-YR5neeenIfJlgZnhur6aLf5z00MACGDywZ9UbihYPIx2qnI+1bhskvaduZY8F+Yv5nESAW0mSkaDnSKtKSBWxQ==",
-      "license": "(Apache-2.0 OR MIT)",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-tile/-/doctype-tile-0.13.3.tgz",
+      "integrity": "sha512-/HsRGQZaSTi9V4oU0sVCOszKig6CfTDwIvmH1YFTVIGixWwjYB/dX01UrvP7g3cDXj4uWiMlHhxrkJbexrP+Zg==",
       "dependencies": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ethersproject/base64": "^5.0.2",
-        "@ethersproject/random": "^5.0.2",
-        "base64url": "^3.0.1",
-        "cids": "1.0.2",
-        "did-jwt": "^4.6.3",
-        "did-resolver": "^2.1.1",
-        "dids": "^1.1.0",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@stablelib/random": "^1.0.0",
         "fast-json-patch": "^2.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "uint8arrays": "^2.0.5"
       }
     },
     "node_modules/@ceramicnetwork/doctype-tile-handler": {
@@ -1409,23 +1451,31 @@
         "web-encoding": "^1.0.5"
       }
     },
+    "node_modules/@ceramicnetwork/doctype-tile/node_modules/uint8arrays": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+      "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.5"
+      }
+    },
     "node_modules/@ceramicnetwork/http-client": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-0.9.3.tgz",
-      "integrity": "sha512-Q0S2/BZ36P4AuWnj0XnwU8eRPArdvXh+UXUI0aL9gdWu454i1j/VobwDKoLoMksK7BU+wAQdG6Sxigz2gMwPrg==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-0.9.6.tgz",
+      "integrity": "sha512-KzKSJuwCQMEp9BpOULm6bx+lTELhB7XQ2noLsTnfHsWsviVWjJXLCNwh6KcelJ0sAd2zF73h5nkmRh0adaTyRA==",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
-        "@ceramicnetwork/3id-did-resolver": "^0.6.7",
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ceramicnetwork/docid": "^0.4.5",
-        "@ceramicnetwork/doctype-caip10-link": "^0.13.0",
-        "@ceramicnetwork/doctype-tile": "^0.13.0",
+        "@ceramicnetwork/3id-did-resolver": "^0.6.10",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@ceramicnetwork/docid": "^0.4.6",
+        "@ceramicnetwork/doctype-caip10-link": "^0.13.2",
+        "@ceramicnetwork/doctype-tile": "^0.13.3",
         "cids": "1.0.2",
         "cross-fetch": "^3.0.6",
         "did-resolver": "^2.1.1",
-        "dids": "^1.1.0",
-        "key-did-resolver": "^0.2.4",
-        "lodash.clonedeep": "^4.5.0"
+        "dids": "^1.1.1",
+        "key-did-resolver": "^0.2.5"
       }
     },
     "node_modules/@ceramicnetwork/pinning-aggregation": {
@@ -2003,6 +2053,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
       "integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8"
@@ -4138,19 +4189,6 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -5662,6 +5700,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -7473,16 +7512,6 @@
         "ipld-dag-cbor": "^0.17.0"
       }
     },
-    "node_modules/dag-jose": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-0.3.0.tgz",
-      "integrity": "sha512-2utzhBhsrMf7nnpqnT2MVm/2aLhwGSbbSpIDvHN6czvTk1mqrxg6L/VR7QdF2qLOeW90A5ZQ4OpN672TZ6LM5Q==",
-      "dependencies": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "uint8arrays": "^1.1.0"
-      }
-    },
     "node_modules/dag-jose-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-0.1.0.tgz",
@@ -9160,7 +9189,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
       "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -16400,14 +16428,23 @@
       }
     },
     "node_modules/key-did-resolver": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-0.2.4.tgz",
-      "integrity": "sha512-/dtq2eHKavlPZKpx5vdBW+vHN7nY4kMCAlg1FzeNqwLT9kYvuQQezSZgW6DDJDR2QZUaHT9MG4dvB8K18wj+6A==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-0.2.5.tgz",
+      "integrity": "sha512-JQrR4/3Tt/Tqc+PwfgdUHPK/AEIWMEHhmhp/+Mq5dMFxQVp4cKLO1cIpLZoM+xROIYwufG6SbU99YlWZfIu3OA==",
       "dependencies": {
         "@stablelib/ed25519": "^1.0.1",
         "multibase": "3.0.1",
-        "uint8arrays": "^1.1.0",
+        "uint8arrays": "^2.0.5",
         "varint": "^6.0.0"
+      }
+    },
+    "node_modules/key-did-resolver/node_modules/uint8arrays": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+      "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+      "dependencies": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.5"
       }
     },
     "node_modules/keypair": {
@@ -25942,15 +25979,27 @@
       "dev": true
     },
     "@ceramicnetwork/3id-did-resolver": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.6.7.tgz",
-      "integrity": "sha512-AQodHN5OK5UbKKi2pMsgwEK5/N4sG+ayin3BDSNVTpP5OJEllj7inNlKuH7LfCUMphwJTX6SULIaZtHex9j+sg==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.6.10.tgz",
+      "integrity": "sha512-v+tCi2r3x+/B7fquFNUeJk9MYkK23C5/unylAl6MTik4TP1Je8WtFsvlYMd6jNBcg7Kun5tjdoFs+IT6o5w5kA==",
       "requires": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ceramicnetwork/docid": "^0.4.5",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@ceramicnetwork/docid": "^0.4.6",
         "cids": "1.0.2",
         "cross-fetch": "^3.0.6",
-        "uint8arrays": "^1.1.0"
+        "lru_map": "^0.4.1",
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "@ceramicnetwork/blockchain-utils-linking": {
@@ -26006,19 +26055,30 @@
       }
     },
     "@ceramicnetwork/common": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-0.15.7.tgz",
-      "integrity": "sha512-7TSOFiTvvM/eFeT671og6ihbiYzlUPIA6DCzAuQHjN2Nme+o5+oiLZaFqwYvpytz0ISs/1jXSUsFfkQEkilphw==",
+      "version": "0.15.9",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-0.15.9.tgz",
+      "integrity": "sha512-ubUgDToLpsd6QELZi9RsMUsr1H4mNtjPwaGRJwT4rMt9lJalHtaw+KoOJLcSeEED6CzQEZUsBxlI9Dr33W4Bew==",
       "requires": {
-        "@ceramicnetwork/docid": "^0.4.5",
+        "@ceramicnetwork/docid": "^0.4.6",
         "cids": "1.0.2",
-        "dag-jose": "^0.3.0",
         "did-resolver": "^2.1.1",
+        "events": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
         "loglevel": "^1.7.0",
         "loglevel-plugin-prefix": "^0.8.4",
         "lru_map": "^0.4.1",
-        "uint8arrays": "^1.1.0"
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "@ceramicnetwork/core": {
@@ -26060,24 +26120,59 @@
       }
     },
     "@ceramicnetwork/docid": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.4.5.tgz",
-      "integrity": "sha512-mrWqkM1hLSjNBIsca7Kex0TfSVxfi/r9X0113H/T3FxSQHwtFteOQLNwMjGpV5RnKcdjwUQgml1cQUnJIRmmDQ==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.4.6.tgz",
+      "integrity": "sha512-fZbmtOkgK8D6eKACRUAT3m6jvNyhAi2Q9pivugld9pc5CzmGYEtDAwtTdNr1eugMVAxxN04UhOENBr0lW9RFKA==",
       "requires": {
         "cids": "1.0.2",
         "multibase": "3.0.1",
-        "multicodec": "2.0.4",
-        "uint8arrays": "^1.1.0",
+        "multicodec": "2.0.0",
+        "uint8arrays": "^2.0.5",
         "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "multicodec": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+          "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+              "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            },
+            "varint": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+            }
+          }
+        },
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "@ceramicnetwork/doctype-caip10-link": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-caip10-link/-/doctype-caip10-link-0.13.0.tgz",
-      "integrity": "sha512-/FzokYBeduVFIuqVGWvfa+ToNGzXn2crTmvxj61oWDI08NHTqHni3ewD91q0qeZv8F3nj4dzff1NujMs5u/glQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-caip10-link/-/doctype-caip10-link-0.13.2.tgz",
+      "integrity": "sha512-sHOB8Uh/4ivvMhfkk3QobAJytce1vzgSamXKjjcjaeAoviqOG5d4XgJ07uoeQVANpmBN4yzRlnxuMtX1b9UALw==",
       "requires": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@types/lodash.clonedeep": "^4.5.6",
+        "@ceramicnetwork/common": "^0.15.9",
         "cids": "1.0.2"
       }
     },
@@ -26093,21 +26188,25 @@
       }
     },
     "@ceramicnetwork/doctype-tile": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-tile/-/doctype-tile-0.13.0.tgz",
-      "integrity": "sha512-YR5neeenIfJlgZnhur6aLf5z00MACGDywZ9UbihYPIx2qnI+1bhskvaduZY8F+Yv5nESAW0mSkaDnSKtKSBWxQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/doctype-tile/-/doctype-tile-0.13.3.tgz",
+      "integrity": "sha512-/HsRGQZaSTi9V4oU0sVCOszKig6CfTDwIvmH1YFTVIGixWwjYB/dX01UrvP7g3cDXj4uWiMlHhxrkJbexrP+Zg==",
       "requires": {
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ethersproject/base64": "^5.0.2",
-        "@ethersproject/random": "^5.0.2",
-        "base64url": "^3.0.1",
-        "cids": "1.0.2",
-        "did-jwt": "^4.6.3",
-        "did-resolver": "^2.1.1",
-        "dids": "^1.1.0",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@stablelib/random": "^1.0.0",
         "fast-json-patch": "^2.2.1",
-        "fast-json-stable-stringify": "^2.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "@ceramicnetwork/doctype-tile-handler": {
@@ -26136,21 +26235,20 @@
       }
     },
     "@ceramicnetwork/http-client": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-0.9.3.tgz",
-      "integrity": "sha512-Q0S2/BZ36P4AuWnj0XnwU8eRPArdvXh+UXUI0aL9gdWu454i1j/VobwDKoLoMksK7BU+wAQdG6Sxigz2gMwPrg==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/http-client/-/http-client-0.9.6.tgz",
+      "integrity": "sha512-KzKSJuwCQMEp9BpOULm6bx+lTELhB7XQ2noLsTnfHsWsviVWjJXLCNwh6KcelJ0sAd2zF73h5nkmRh0adaTyRA==",
       "requires": {
-        "@ceramicnetwork/3id-did-resolver": "^0.6.7",
-        "@ceramicnetwork/common": "^0.15.7",
-        "@ceramicnetwork/docid": "^0.4.5",
-        "@ceramicnetwork/doctype-caip10-link": "^0.13.0",
-        "@ceramicnetwork/doctype-tile": "^0.13.0",
+        "@ceramicnetwork/3id-did-resolver": "^0.6.10",
+        "@ceramicnetwork/common": "^0.15.9",
+        "@ceramicnetwork/docid": "^0.4.6",
+        "@ceramicnetwork/doctype-caip10-link": "^0.13.2",
+        "@ceramicnetwork/doctype-tile": "^0.13.3",
         "cids": "1.0.2",
         "cross-fetch": "^3.0.6",
         "did-resolver": "^2.1.1",
-        "dids": "^1.1.0",
-        "key-did-resolver": "^0.2.4",
-        "lodash.clonedeep": "^4.5.0"
+        "dids": "^1.1.1",
+        "key-did-resolver": "^0.2.5"
       }
     },
     "@ceramicnetwork/pinning-aggregation": {
@@ -26527,6 +26625,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
       "integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8"
@@ -28380,19 +28479,6 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -29689,7 +29775,8 @@
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -31300,16 +31387,6 @@
         "ipld-dag-cbor": "^0.17.0"
       }
     },
-    "dag-jose": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-0.3.0.tgz",
-      "integrity": "sha512-2utzhBhsrMf7nnpqnT2MVm/2aLhwGSbbSpIDvHN6czvTk1mqrxg6L/VR7QdF2qLOeW90A5ZQ4OpN672TZ6LM5Q==",
-      "requires": {
-        "borc": "^2.1.2",
-        "cids": "^1.0.0",
-        "uint8arrays": "^1.1.0"
-      }
-    },
     "dag-jose-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dag-jose-utils/-/dag-jose-utils-0.1.0.tgz",
@@ -32747,8 +32824,7 @@
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
-      "dev": true
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -38841,14 +38917,25 @@
       }
     },
     "key-did-resolver": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-0.2.4.tgz",
-      "integrity": "sha512-/dtq2eHKavlPZKpx5vdBW+vHN7nY4kMCAlg1FzeNqwLT9kYvuQQezSZgW6DDJDR2QZUaHT9MG4dvB8K18wj+6A==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/key-did-resolver/-/key-did-resolver-0.2.5.tgz",
+      "integrity": "sha512-JQrR4/3Tt/Tqc+PwfgdUHPK/AEIWMEHhmhp/+Mq5dMFxQVp4cKLO1cIpLZoM+xROIYwufG6SbU99YlWZfIu3OA==",
       "requires": {
         "@stablelib/ed25519": "^1.0.1",
         "multibase": "3.0.1",
-        "uint8arrays": "^1.1.0",
+        "uint8arrays": "^2.0.5",
         "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "keypair": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/store": "^2.0.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "^8.2.2",
+    "dag-jose": "^0.3.0",
     "eslint": "^7.15.0",
     "eslint-config-3box": "^0.2.0",
     "ipfs": "^0.52.3",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "homepage": "https://github.com/ceramicstudio/js-3id-did-provider#readme",
   "dependencies": {
     "@babel/runtime": "^7.12.1",
-    "@ceramicnetwork/doctype-tile": "^0.13.0",
-    "@ceramicnetwork/http-client": "^0.9.3",
+    "@ceramicnetwork/doctype-tile": "^0.13.3",
+    "@ceramicnetwork/http-client": "^0.9.6",
     "@ceramicstudio/idx-constants": "^0.6.0",
     "@ethersproject/hdnode": "^5.0.8",
     "@stablelib/random": "^1.0.0",

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -45,8 +45,12 @@ interface FullKeySet {
 
 function deriveKeySet(seed: Uint8Array, v03ID?: string): FullKeySet {
   const seedNode = HDNode.fromSeed(seed)
-  let hdNode = seedNode.derivePath(BASE_PATH)
-  if (v03ID) hdNode = seedNode.derivePath(LEGACY_BASE_PATH)
+  let hdNode
+  if (v03ID) {
+    hdNode = seedNode.derivePath(LEGACY_BASE_PATH)
+  } else {
+    hdNode = seedNode.derivePath(BASE_PATH)
+  }
   const signing = hdNode.derivePath('0')
   // for v03ID the signing key is the management key
   const management = v03ID ? signing : hdNode.derivePath('1')

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -18,7 +18,7 @@ import { encodeKey, hexToU8A, u8aToHex } from './utils'
 export const LATEST = 'latest'
 const GENESIS = 'genesis'
 const BASE_PATH = "m/51073068'"
-const ROOT_STORE_PATH = "0'/0'/0'/0'/0'/0'/0'/0'/0'"
+const LEGACY_BASE_PATH = "m/7696500'/0'/0'"
 
 interface ThreeIdMetadata extends Record<string, any> {
   controllers: Array<string>
@@ -44,8 +44,9 @@ interface FullKeySet {
 }
 
 function deriveKeySet(seed: Uint8Array, v03ID?: string): FullKeySet {
-  let hdNode = HDNode.fromSeed(seed).derivePath(BASE_PATH)
-  if (v03ID) hdNode = hdNode.derivePath(ROOT_STORE_PATH)
+  const seedNode = HDNode.fromSeed(seed)
+  let hdNode = seedNode.derivePath(BASE_PATH)
+  if (v03ID) hdNode = seedNode.derivePath(LEGACY_BASE_PATH)
   const signing = hdNode.derivePath('0')
   // for v03ID the signing key is the management key
   const management = v03ID ? signing : hdNode.derivePath('1')

--- a/test/__snapshots__/keyring.test.js.snap
+++ b/test/__snapshots__/keyring.test.js.snap
@@ -113,7 +113,7 @@ Object {
   "deterministic": true,
   "metadata": Object {
     "controllers": Array [
-      "did:key:zQ3shnyMbHDVqqJnm6EiPJ47Vc4ivUFgcaPpEHx9GhyFT5Env",
+      "did:key:zQ3shbBE65QyvqVfo5yNpzN4Qf4LypkgdsoMyjoWbWz79r6j4",
     ],
     "family": "3id",
   },
@@ -124,7 +124,7 @@ exports[`Keyring Generates correct state if v03ID is set 2`] = `
 Object {
   "metadata": Object {
     "controllers": Array [
-      "did:key:zQ3shnyMbHDVqqJnm6EiPJ47Vc4ivUFgcaPpEHx9GhyFT5Env",
+      "did:key:zQ3shbBE65QyvqVfo5yNpzN4Qf4LypkgdsoMyjoWbWz79r6j4",
     ],
   },
 }

--- a/test/__snapshots__/threeid-provider.test.js.snap
+++ b/test/__snapshots__/threeid-provider.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#g75q7J22wuWRyHb",
+      "publicKey": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#7uFZ8RP1qUVU87P",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
@@ -21,8 +21,8 @@ Object {
   "publicKey": Array [
     Object {
       "controller": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu",
-      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#g75q7J22wuWRyHb",
-      "publicKeyBase58": "P8fYfHCRRHYkNwtVjRadhgftUsyEr6FUy65WttgSjqaW2eDXvJeXuCZRTdFM9JXc72eS5EDuu52fsdthsuWN7TS1",
+      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#7uFZ8RP1qUVU87P",
+      "publicKeyBase58": "h3ZsRvyVTpF6NheK7BZGaKeFv2K4qZridCfaiVoNFeFf",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {

--- a/test/__snapshots__/threeid-provider.test.js.snap
+++ b/test/__snapshots__/threeid-provider.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#awRV3csnRHjJpWt",
+      "publicKey": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#g75q7J22wuWRyHb",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
@@ -13,22 +13,22 @@ Object {
   "keyAgreement": Array [
     Object {
       "controller": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu",
-      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#38JciKPaAyHMu5r",
-      "publicKeyBase58": "AVgughn1R4BTrRL2gP6ZmVAhWrzTHRx9jjbi5iKkeXK6",
+      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#FRNNWcZDvDZcpVC",
+      "publicKeyBase58": "qFYM1z9dJUC1K7rphEDVCj8U1YTzeFDVXtsjTa2uSiS",
       "type": "X25519KeyAgreementKey2019",
     },
   ],
   "publicKey": Array [
     Object {
       "controller": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu",
-      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#awRV3csnRHjJpWt",
-      "publicKeyBase58": "jidgTminnrVUvPAFM3E1w1MYwN2cZ2ttZ7s5V5cc6LfA",
+      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#g75q7J22wuWRyHb",
+      "publicKeyBase58": "P8fYfHCRRHYkNwtVjRadhgftUsyEr6FUy65WttgSjqaW2eDXvJeXuCZRTdFM9JXc72eS5EDuu52fsdthsuWN7TS1",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu",
-      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#38JciKPaAyHMu5r",
-      "publicKeyBase58": "AVgughn1R4BTrRL2gP6ZmVAhWrzTHRx9jjbi5iKkeXK6",
+      "id": "did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu#FRNNWcZDvDZcpVC",
+      "publicKeyBase58": "qFYM1z9dJUC1K7rphEDVCj8U1YTzeFDVXtsjTa2uSiS",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
@@ -40,31 +40,31 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y#DAyzBZtFSbmcYwd",
+      "publicKey": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs#e2Z2Dq3958ZPPWA",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
-  "id": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y",
+  "id": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs",
   "keyAgreement": Array [
     Object {
-      "controller": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y",
-      "id": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y#zdTJrUZnZiEUpZ7",
-      "publicKeyBase58": "H6eKDZXoFYnZK7LmCETqNrdJSs3D1PTJRsktJ74hmSnM",
+      "controller": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs",
+      "id": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs#RvxVH2RhN7KTkKk",
+      "publicKeyBase58": "9iv4ZyqUetpcFe4cQuoRwjhUDc42spkocJJkCuTnkNYz",
       "type": "X25519KeyAgreementKey2019",
     },
   ],
   "publicKey": Array [
     Object {
-      "controller": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y",
-      "id": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y#DAyzBZtFSbmcYwd",
-      "publicKeyBase58": "sa7zneXscD3PdWhAopVWoN8sNMxDCf8T4Fp5x6veQ55u",
-      "type": "Secp256k1VerificationKey2018",
+      "controller": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs",
+      "id": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs#RvxVH2RhN7KTkKk",
+      "publicKeyBase58": "9iv4ZyqUetpcFe4cQuoRwjhUDc42spkocJJkCuTnkNYz",
+      "type": "Curve25519EncryptionPublicKey",
     },
     Object {
-      "controller": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y",
-      "id": "did:3:kjzl6cwe1jw148alhwpftxgyonvf6ne1yj9480rrxqtdri7fuxljd4m8brmh25y#zdTJrUZnZiEUpZ7",
-      "publicKeyBase58": "H6eKDZXoFYnZK7LmCETqNrdJSs3D1PTJRsktJ74hmSnM",
-      "type": "Curve25519EncryptionPublicKey",
+      "controller": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs",
+      "id": "did:3:kjzl6cwe1jw145sk1o41vwmkne6kw9g928uot09nf6bzlv1814vrs3xeybiovvs#e2Z2Dq3958ZPPWA",
+      "publicKeyBase58": "25sGY37UkdKKW4irbH9qxdxRUvqYZi5z26J5EqjTSAueS",
+      "type": "Secp256k1VerificationKey2018",
     },
   ],
 }

--- a/test/threeid-provider.test.js
+++ b/test/threeid-provider.test.js
@@ -15,7 +15,7 @@ import legacy from 'multiformats/cjs/src/legacy.js'
 import * as u8a from 'uint8arrays'
 
 const KEYCHAIN_DEF = definitions.threeIdKeychain
-const seed = u8a.fromString('6e34b2e1a9624113d81ece8a8a22e6e97f0e145c25c1d4d2d0e62753b4060c837097f768559e17ec89ee20cba153b23b9987912ec1e860fa1212ba4b84c776ce', 'base16')
+const seed = u8a.fromString('af0253c646e3d6ccf93758154f55b6055ab5739e22d54fb0b3b6ad1819c73ffaaca52378afeda236f41755c59db9e8aeb30d4cefbd61327603ba6aee63a59b1d', 'base16')
 
 const randomAuthSecret = () => randomBytes(32)
 const getPermissionMock = jest.fn(async () => [])
@@ -42,11 +42,11 @@ jest.mock('cross-fetch', (o) => {
         publicKey: [{
           id: 'did:3:GENESIS#signingKey',
           type: 'Secp256k1VerificationKey2018',
-          publicKeyHex: '027ab5238257532f486cbeeac59a5721bbfec2f13c3d26516ca9d4c5f0ec1aa229'
+          publicKeyHex: '0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2'
         }, {
           id: 'did:3:GENESIS#encryptionKey',
           type: 'Curve25519EncryptionPublicKey',
-          publicKeyBase64: 'jRKRy3oPhXpUBrFJefO2CJnWw/IoalOPuepAwvTqrEk'
+          publicKeyBase64: 'DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc='
         }],
         authentication: [{
           type: 'Secp256k1SignatureAuthentication2018',
@@ -188,7 +188,7 @@ describe('ThreeIdProvider', () => {
     })
 
     it('Does keyrotation when v03ID is being used', async () => {
-      const v03ID = 'did:3:bafyreidv6yl2bbmuslkqby45hdn6sd6ha22zlolxjjxxz4suuwfqpezewu'
+      const v03ID = 'did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi'
       const config = {
         getPermission: getPermissionMock,
         seed,


### PR DESCRIPTION
Changes root key derivation path (to what exist in 3box/3id-connect, would have been root store path if migration had occurred in 3box, but ceramic migration path was favored over completing that migration )

One issue remains, did resolver when resolving legacy dids (mocked in test here for example) throws 'not a valid 3id' when using an uncompressed signing key. Results in failed test here, while same key compressed passes. 

ie https://ipfs.3box.io/did-doc?cid=bafyreiclczgrdjl2v35qn45exhl6smubydid4nv6ailtjqsuq6lu3hen2a